### PR TITLE
fix for #29224 ensure firelocks stay open a consistent time

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -34,6 +34,7 @@
 	var/active_alarm = FALSE
 	var/heat_resistance = 15000
 	var/list/affecting_areas
+	var/last_opened_time = 0
 
 /obj/machinery/door/firedoor/Initialize(mapload)
 	. = ..()
@@ -256,6 +257,7 @@
 	if(welded)
 		return
 	. = ..()
+	last_opened_time = world.time
 	latetoggle()
 	if(active_alarm)
 		layer = closingLayer // Active firedoors take precedence and remain visible over closed airlocks.
@@ -284,6 +286,10 @@
 		open()
 	else
 		close()
+
+/obj/machinery/door/firedoor/proc/can_be_closed_by_alarm()
+	// Only allow closing if at least 5 seconds have passed since last opened
+	return (world.time - last_opened_time) >= 5 SECONDS
 
 /obj/machinery/door/firedoor/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))


### PR DESCRIPTION


<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes issue #29224 and stops fire doors closing immediately after being opened
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Stops an issue that has been raised and allows players to open firedoors without them closing on them immediately
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->
Tested using BYOND
## Declaration

- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:

fix: Fixed a few things

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
